### PR TITLE
fixes the ingress deprecation message.

### DIFF
--- a/charts/gotenberg/templates/NOTES.txt
+++ b/charts/gotenberg/templates/NOTES.txt
@@ -1,7 +1,7 @@
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
-{{- range .Values.ingress.hosts }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- range $host := .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "gotenberg.fullname" . }})

--- a/charts/gotenberg/templates/ingress.yaml
+++ b/charts/gotenberg/templates/ingress.yaml
@@ -1,7 +1,18 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "gotenberg.fullname" . -}}
-{{- $ingressPath := .Values.ingress.path -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -20,7 +31,7 @@ metadata:
 {{ else }}
   annotations:
 {{- with .Values.ingress.annotations }}
-{{ toYaml . | indent 4 }}  
+{{ toYaml . | indent 4 }}
 {{- end }}
 {{- end }}
 spec:
@@ -36,12 +47,24 @@ spec:
 {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
-    - host: {{ . }}
+    - host: {{ .host | quote }}
       http:
         paths:
-          - path: {{ $ingressPath }}
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: http
+              {{- end }}
+          {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -20,12 +20,15 @@ basicAuth:
 
 ingress:
   enabled: false
+  className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  path: /
   hosts:
-    - gotenberg.local
+    - host: gotenberg.local
+      paths:
+        - path: /
+          pathType: Prefix
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
Please keep in my that this is a breaking change, since the YAML definition for Ingress has changed.
So I guess you'll need to "tag" 3.0.0 of this Helm Chart (sorry).

What I've done: 

- Created a new Helm Chart, copied the Ingress Part of it to the Gotenberg chart.
- Updated notes.txt so it will use the new Ingress format.
- Tested it on a Kubernetes 1.21.1 cluster with NGINX Ingress. 
- Tested it on a Kubernetes 1.19.4 cluster with HAProxy Ingress.

Fixes #31 