### PR TITLE
Gotenberg: Labels and selectors

### DIFF
--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
-appVersion: "7.0.3"
+appVersion: "7.5.0"
 description: Gotenberg is a Docker-powered stateless API for converting HTML, Markdown and Office documents to PDF.
 name: gotenberg
 icon: https://user-images.githubusercontent.com/8983173/69229423-ac731300-0b85-11ea-8c2e-2cc00ecdb269.PNG
-version: 5.0.0
+version: 5.1.0
 home: https://thecodingmachine.github.io/gotenberg/
 sources:
   - https://github.com/thecodingmachine/gotenberg

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -1,7 +1,7 @@
 # gotenberg
 
 Gotenberg is a Docker-powered stateless API for converting HTML, Markdown and Office documents to PDF.
-5.0.0
+5.1.0
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/kurt108)](https://artifacthub.io/packages/search?repo=kurt108)
 
 =======
@@ -41,12 +41,11 @@ NAME: my-release
 | basicAuth.enabled | bool | `false` |  |
 | basicAuth.passwordMD5 | string | `"$apr1$zQ7F0fKS$X3aXkUCufHQlVe51VWUKu1"` |  |
 | basicAuth.username | string | `"convert"` |  |
-| env.open.GOTENBERG_VERSION | string | `"7.0.3"` |  |
 | env.open.LOG_FORMAT | string | `"TEXT"` |  |
 | env.open.LOG_LEVEL | string | `"DEBUG"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"gotenberg/gotenberg"` |  |
-| image.tag | string | `"7.0.3"` |  |
+| image.tag | string | `"7.5.0"` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
 | ingress.enabled | bool | `true` |  |
@@ -59,6 +58,7 @@ NAME: my-release
 | podDisruptionBudget.maxUnavailable | int | `1` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
+| service.labels | object | `{}` |  |
 | service.port | int | `3000` |  |
 | service.type | string | `"ClusterIP"` |  |
 | tolerations | list | `[]` |  |

--- a/charts/gotenberg/templates/_helpers.tpl
+++ b/charts/gotenberg/templates/_helpers.tpl
@@ -30,3 +30,34 @@ Create chart name and version as used by the chart label.
 {{- define "gotenberg.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "gotenberg.labels" -}}
+helm.sh/chart: {{ include "gotenberg.chart" . }}
+{{ include "gotenberg.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gotenberg.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gotenberg.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "gotenberg.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "gotenberg.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/gotenberg/templates/deployment.yaml
+++ b/charts/gotenberg/templates/deployment.yaml
@@ -3,9 +3,9 @@ kind: Deployment
 metadata:
   name: {{ template "gotenberg.fullname" . }}
   labels:
+    {{ include "gotenberg.labels" . | nindent 4 }}
     app: {{ template "gotenberg.name" . }}
     chart: {{ template "gotenberg.chart" . }}
-    release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
 {{- if .Values.annotations }}
@@ -15,13 +15,11 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "gotenberg.name" . }}
-      release: {{ .Release.Name }}
+      {{- include "gotenberg.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ template "gotenberg.name" . }}
-        release: {{ .Release.Name }}
+        {{- include "gotenberg.selectorLabels" . | nindent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
     spec:
@@ -43,19 +41,19 @@ spec:
             - name: {{ $name | quote }}
               value: {{ $value | quote }}
           {{- end }}
-          {{- end }}              
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /health
               port: {{ .Values.service.port }}
             initialDelaySeconds: 5
-            periodSeconds: 60  
+            periodSeconds: 60
           readinessProbe:
             httpGet:
               path: /health
               port: {{ .Values.service.port }}
             initialDelaySeconds: 5
-            periodSeconds: 60                
+            periodSeconds: 60
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/charts/gotenberg/templates/hpa.yaml
+++ b/charts/gotenberg/templates/hpa.yaml
@@ -4,6 +4,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "gotenberg.fullname" . }}
   labels:
+    {{ include "gotenberg.labels" . | nindent 4 }}
     app: {{ template "gotenberg.name" . }}
     release: {{ .Release.Name }}
 spec:

--- a/charts/gotenberg/templates/ingress.yaml
+++ b/charts/gotenberg/templates/ingress.yaml
@@ -17,6 +17,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
+    {{ include "gotenberg.labels" . | nindent 4 }}
     app: {{ template "gotenberg.name" . }}
     chart: {{ template "gotenberg.chart" . }}
     release: {{ .Release.Name }}
@@ -31,7 +32,7 @@ metadata:
 {{ else }}
   annotations:
 {{- with .Values.ingress.annotations }}
-{{ toYaml . | indent 4 }}  
+{{ toYaml . | indent 4 }}
 {{- end }}
 {{- end }}
 spec:
@@ -61,10 +62,10 @@ spec:
                  name: {{ $fullName }}
                  port:
                    number: {{ $svcPort }}
-               {{- else }}            
+               {{- else }}
               serviceName: {{ $fullName }}
               servicePort: http
               {{- end }}
-           {{- end }}              
+           {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/gotenberg/templates/pdb.yaml
+++ b/charts/gotenberg/templates/pdb.yaml
@@ -5,6 +5,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ include "gotenberg.fullname" . }}
   labels:
+    {{ include "gotenberg.labels" . | nindent 4 }}
     app: {{ template "gotenberg.name" . }}
     chart: {{ template "gotenberg.chart" . }}
     release: {{ .Release.Name }}
@@ -12,7 +13,6 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ template "gotenberg.name" . }}
-      release: {{ .Release.Name }}
+      {{- include "gotenberg.selectorLabels" . | nindent 6 }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
 {{- end }}

--- a/charts/gotenberg/templates/secrets.yaml
+++ b/charts/gotenberg/templates/secrets.yaml
@@ -6,6 +6,7 @@ kind: Secret
 metadata:
   name: {{ template "gotenberg.fullname" . }}
   labels:
+    {{ include "gotenberg.labels" . | nindent 4 }}
     app: {{ template "gotenberg.name" . }}
     chart: {{ template "gotenberg.chart" . }}
     release: {{ .Release.Name }}
@@ -14,4 +15,3 @@ type: Opaque
 data:
   auth: {{ (printf "%s:%s"  .Values.basicAuth.username .Values.basicAuth.passwordMD5) | b64enc | quote }}
 {{- end }}
-

--- a/charts/gotenberg/templates/service.yaml
+++ b/charts/gotenberg/templates/service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: {{ template "gotenberg.fullname" . }}
   labels:
+    {{ include "gotenberg.labels" . | nindent 4 }}
     app: {{ template "gotenberg.name" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -17,5 +18,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: {{ template "gotenberg.name" . }}
-    release: {{ .Release.Name }}
+    {{- include "gotenberg.selectorLabels" . | nindent 4 }}

--- a/charts/gotenberg/templates/service.yaml
+++ b/charts/gotenberg/templates/service.yaml
@@ -6,6 +6,9 @@ metadata:
     app: {{ template "gotenberg.name" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.service.labels }}
+    {{ toYaml .Values.service.labels }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/gotenberg/templates/vpa.yaml
+++ b/charts/gotenberg/templates/vpa.yaml
@@ -4,6 +4,7 @@ kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "gotenberg.fullname" . }}
   labels:
+    {{ include "gotenberg.labels" . | nindent 4 }}
     app: {{ template "gotenberg.name" . }}
     chart: {{ template "gotenberg.chart" . }}
     release: {{ .Release.Name }}

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -6,12 +6,11 @@ replicaCount: 1
 
 image:
   repository: gotenberg/gotenberg
-  tag: 7.0.3
+  tag: 7.5.0
   pullPolicy: IfNotPresent
 
 env:
   open:
-    GOTENBERG_VERSION: "7.0.3"
     LOG_FORMAT: "TEXT"
     LOG_LEVEL: "DEBUG"
 

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -18,6 +18,7 @@ env:
 service:
   type: ClusterIP
   port: 3000
+  labels: {}
 
 basicAuth:
   enabled: false


### PR DESCRIPTION
Edit: fails because it needs https://github.com/Kurt108/helm-charts/pull/40

- Allows users to set custom service labels
- Switches to using a template to set the selector labels in the service, deployment and pdb objects
- gotenberg 7.5.0