### PR TITLE
doc(thumbor): fix readme

### DIFF
--- a/charts/thumbor/README.md
+++ b/charts/thumbor/README.md
@@ -1,7 +1,7 @@
 # thumbor
 
 A chart containing Thumbor
-1.0.29
+1.0.30
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/kurt108)](https://artifacthub.io/packages/search?repo=kurt108)
 
 Based on the fanastic work from Cloudposse: https://charts.cloudposse.com/incubator/
@@ -61,4 +61,3 @@ NAME: my-release
 | resources.requests.memory | string | `"512Mi"` |  |
 | service.name | string | `"thumbor"` |  |
 | service.type | string | `"ClusterIP"` |  |
-| affinity | dictionary | `{}` | Affinity for pod assignment |


### PR DESCRIPTION
the thumbor chart readme is out of date and causes the helm-docs github action to fail