### PR TITLE
Update DPB API version from v1beta1 to v1

### DIFF
--- a/charts/gotenberg/templates/pdb.yaml
+++ b/charts/gotenberg/templates/pdb.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.podDisruptionBudget.enabled }}
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "gotenberg.fullname" . }}


### PR DESCRIPTION
The `v1beta1` API for PodDisruptionBudgets is being removed in kubernetes version 1.25 after being deprecated in 1.21 so it needs to be updated.