### PR TITLE
Fix/image pull secrets at wrong place

### DIFF
--- a/charts/gotenberg/templates/deployment.yaml
+++ b/charts/gotenberg/templates/deployment.yaml
@@ -12,10 +12,6 @@ metadata:
 {{ toYaml .Values.annotations | indent 8 }}
 {{- end }}
 spec:
-  {{- with .Values.imagePullSecrets }}
-  imagePullSecrets:
-    {{- toYaml . | nindent 8 }}
-  {{- end }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
@@ -27,6 +23,10 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsUser: 1001
         runAsGroup: 1001

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -9,8 +9,7 @@ image:
   tag: 7.5.0
   pullPolicy: IfNotPresent
 
-imagePullSecrets:
-  - name: ""
+imagePullSecrets: []
 
 env:
   open:


### PR DESCRIPTION
When I tried to upgrade my helm chart from 5.2.0 to 5.3.0 then I got the following error:

failed to create typed patch object (my-services/html-to-pdf-gotenberg; apps/v1, Kind=Deployment): .spec.imagePullSecrets: field not declared in schema

imagePullSecrets property is at the wrong level. 